### PR TITLE
Reduce rand dependency to rand_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,12 @@ edition = "2018"
 algebra = { git = "https://github.com/scipr-lab/zexe/", features = [ "parallel" ] }
 ff-fft = { git = "https://github.com/scipr-lab/zexe/" }
 bench-utils = { git = "https://github.com/scipr-lab/zexe/" }
-rand = { version = "0.7" }
+rand_core = { version = "0.5" }
 rayon = { version = "1" }
 derivative = { version = "1" }
+
+[dev-dependencies]
+rand = { version = "0.7" }
 
 [profile.release]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ extern crate bench_utils;
 
 use algebra::Field;
 pub use ff_fft::DensePolynomial as Polynomial;
-use rand::Rng;
+use rand_core::RngCore;
 use std::borrow::Cow;
 
 /// Defines `SinglePolynomialCommitment` schemes that allow one to commit to
@@ -67,7 +67,7 @@ pub trait PCRandomness: Clone {
 
     /// Samples randomness for commitments;
     /// `num_queries` specifies the number of queries that the commitment will be opened at.
-    fn rand<R: Rng>(num_queries: usize, rng: &mut R) -> Self;
+    fn rand<R: RngCore>(num_queries: usize, rng: &mut R) -> Self;
 }
 
 /// A polynomial along with information about its degree bound (if any), and the

--- a/src/multi_pc/mod.rs
+++ b/src/multi_pc/mod.rs
@@ -1,5 +1,5 @@
 use algebra::Field;
-use rand::RngCore;
+use rand_core::RngCore;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::*;

--- a/src/multi_pc/mpc_from_spc.rs
+++ b/src/multi_pc/mpc_from_spc.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 
 use algebra::PrimeField;
-use rand::RngCore;
+use rand_core::RngCore;
 
 /// Generic construction of a `MultiPolynomialCommitment` scheme from a
 /// `SinglePolynomialCommitment` scheme whenever the commitment and randomness of the
@@ -525,7 +525,7 @@ where
 // Basically, we define a "dummy rng" that does nothing
 // (corresponding to the case that `rng = None`).
 pub(super) mod optional_rng {
-    use rand::RngCore;
+    use rand_core::RngCore;
     pub(super) struct OptionalRng<R>(pub(super) Option<R>);
 
     impl<R: RngCore> RngCore for OptionalRng<R> {
@@ -545,7 +545,7 @@ pub(super) mod optional_rng {
         }
 
         #[inline]
-        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
             Ok(self.fill_bytes(dest))
         }
     }

--- a/src/single_pc/kzg10.rs
+++ b/src/single_pc/kzg10.rs
@@ -15,7 +15,7 @@ use algebra::{
     AffineCurve, Field, Group, PairingCurve, PairingEngine, PrimeField, ProjectiveCurve,
     UniformRand,
 };
-use rand::RngCore;
+use rand_core::RngCore;
 use rayon::prelude::*;
 use std::marker::PhantomData;
 use std::ops::AddAssign;

--- a/src/single_pc/mod.rs
+++ b/src/single_pc/mod.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use algebra::Field;
-use rand::RngCore;
+use rand_core::RngCore;
 
 /// Describes the interface for a polynomial commitment scheme that allows
 /// a sender to commit to a single polynomial and later provide a succinct proof


### PR DESCRIPTION
I considered adding `+CryptoRng` throughout too, but `multi_pc::mpc_from_spc::optional_rng` scared me off.