### PR TITLE
Add support for checking linear equations of polynomials.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-/// The error type for `KZG10`.
+/// Errors that arise when dealing with query sets.
 #[derive(Debug)]
 pub enum QuerySetError {
     /// The query set contains a label for a polynomial that was not provided as 
@@ -33,6 +33,34 @@ impl std::fmt::Display for QuerySetError {
 }
 
 impl std::error::Error for QuerySetError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+/// Equation errors that arise when dealing with query sets.
+#[derive(Debug)]
+pub enum EquationError {
+    /// The LHS of the equation is empty.
+    MissingLHS {
+        /// The label of the equation.
+        label: String
+    },
+}
+
+impl std::fmt::Display for EquationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EquationError::MissingLHS { label } => write!(
+                f,
+                "Equation \"{}\" does not have a LHS.",
+                label
+            ),
+        }
+    }
+}
+
+impl std::error::Error for EquationError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
     }

--- a/src/kzg10/data_structures.rs
+++ b/src/kzg10/data_structures.rs
@@ -1,6 +1,6 @@
 use algebra::{AffineCurve, ProjectiveCurve, ToBytes, PairingCurve, PairingEngine, PrimeField, Zero};
 use crate::*;
-use std::ops::AddAssign;
+use std::ops::{Add, AddAssign};
 use std::borrow::Cow;
 
 /// `UniversalParams` are the universal parameters for the KZG10 scheme.
@@ -165,6 +165,33 @@ impl<E: PairingEngine> PCRandomness for Randomness<E> {
         let hiding_poly_degree = Self::calculate_hiding_polynomial_degree(hiding_bound);
         randomness.blinding_polynomial = Polynomial::rand(hiding_poly_degree, rng);
         randomness
+    }
+}
+
+impl<'a, E: PairingEngine> Add<&'a Randomness<E>> for Randomness<E> {
+    type Output = Self;
+
+    #[inline]
+    fn add(mut self, other: &'a Self) -> Self {
+        self.blinding_polynomial += &other.blinding_polynomial;
+        self
+    }
+}
+
+impl<'a, E: PairingEngine> Add<(E::Fr, &'a Randomness<E>)> for Randomness<E> {
+    type Output = Self;
+
+    #[inline]
+    fn add(mut self, other: (E::Fr, &'a Randomness<E>)) -> Self {
+        self += other;
+        self
+    }
+}
+
+impl<'a, E: PairingEngine> AddAssign<&'a Randomness<E>> for Randomness<E> {
+    #[inline]
+    fn add_assign(&mut self, other: &'a Self) {
+        self.blinding_polynomial += &other.blinding_polynomial;
     }
 }
 

--- a/src/kzg10/data_structures.rs
+++ b/src/kzg10/data_structures.rs
@@ -160,7 +160,7 @@ impl<E: PairingEngine> PCRandomness for Randomness<E> {
         }
     }
 
-    fn rand<R: RngCore>(hiding_bound: usize, rng: &mut R) -> Self {
+    fn rand<R: RngCore>(hiding_bound: usize, _: bool, rng: &mut R) -> Self {
         let mut randomness = Randomness::empty();
         let hiding_poly_degree = Self::calculate_hiding_polynomial_degree(hiding_bound);
         randomness.blinding_polynomial = Polynomial::rand(hiding_poly_degree, rng);

--- a/src/kzg10/mod.rs
+++ b/src/kzg10/mod.rs
@@ -131,7 +131,7 @@ impl<E: PairingEngine> KZG10<E> {
                 hiding_degree
             ));
 
-            randomness = Randomness::rand(hiding_degree, &mut rng);
+            randomness = Randomness::rand(hiding_degree, false, &mut rng);
             Error::check_hiding_bound(randomness.blinding_polynomial.degree(), powers.powers_of_gamma_g.len())?;
             end_timer!(sample_random_poly_time);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ pub trait PolynomialCommitment<F: Field> {
 
     /// On input a list of labeled polynomials and a query set, `open` outputs a proof of evaluation
     /// of the polynomials at the points in the query set.
-    fn open_equation<'a>(
+    fn open_equations<'a>(
         ck: &Self::CommitterKey,
         equations: impl IntoIterator<Item = &'a Equation<F>>,
         labeled_polynomials: impl IntoIterator<Item = &'a LabeledPolynomial<'a, F>>,
@@ -257,7 +257,7 @@ pub trait PolynomialCommitment<F: Field> {
 
     /// Checks that `values` are the true evaluations at `query_set` of the polynomials
     /// committed in `labeled_commitments`.
-    fn check_equation<'a, R: RngCore>(
+    fn check_equations<'a, R: RngCore>(
         vk: &Self::VerifierKey,
         equations: impl IntoIterator<Item = &'a Equation<F>>,
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
@@ -294,7 +294,6 @@ pub trait PolynomialCommitment<F: Field> {
             eprintln!("Evaluation proofs failed to verify");
             return Ok(false);
         }
-
 
         Ok(true)
     }

--- a/src/marlin_kzg10/data_structures.rs
+++ b/src/marlin_kzg10/data_structures.rs
@@ -227,14 +227,19 @@ impl<E: PairingEngine> PCRandomness for Randomness<E> {
     fn empty() -> Self {
         Self {
             rand: kzg10::Randomness::empty(),
-            shifted_rand: Some(kzg10::Randomness::empty()),
+            shifted_rand: None,
         }
     }
 
-    fn rand<R: RngCore>(hiding_bound: usize, rng: &mut R) -> Self {
+    fn rand<R: RngCore>(hiding_bound: usize, has_degree_bound: bool, rng: &mut R) -> Self {
+        let shifted_rand = if has_degree_bound {
+            Some(kzg10::Randomness::rand(hiding_bound, false, rng))
+        } else {
+            None
+        };
         Self {
-            rand: kzg10::Randomness::rand(hiding_bound, rng),
-            shifted_rand: Some(kzg10::Randomness::rand(hiding_bound, rng)),
+            rand: kzg10::Randomness::rand(hiding_bound, false, rng),
+            shifted_rand,
         }
     }
 }

--- a/src/marlin_kzg10/error.rs
+++ b/src/marlin_kzg10/error.rs
@@ -8,6 +8,9 @@ pub enum Error {
     TrimmingDegreeTooLarge,
     /// The provided `enforced_degree_bounds` was `Some<&[]>`.
     EmptyDegreeBounds,
+    /// The provided equation contained multiple polynomials, of which least one
+    /// had a strict degree bound.
+    EquationHasDegreeBounds(String),
     /// The required degree bound is not supported by ck/vk
     UnsupportedDegreeBound(usize),
     /// The degree bound for the `index`-th polynomial passed to `commit`, `open`
@@ -78,6 +81,8 @@ impl std::fmt::Display for Error {
         match self {
             Error::TrimmingDegreeTooLarge => write!(f, "the degree provided to `trim` was too large"),
             Error::EmptyDegreeBounds => write!(f, "provided `enforced_degree_bounds` was `Some<&[]>`"),
+            Error::EquationHasDegreeBounds(e) => 
+                write!(f, "the eqaution \"{}\" contained degree-bounded polynomials", e),
             Error::UnsupportedDegreeBound(bound) => write!(
                 f,
                 "the degree bound ({:?}) is not supported by the parameters",

--- a/src/marlin_kzg10/error.rs
+++ b/src/marlin_kzg10/error.rs
@@ -1,5 +1,5 @@
 use crate::kzg10;
-use crate::{PCCommitterKey, LabeledPolynomial, QuerySetError as QSError};
+use crate::{PCCommitterKey, LabeledPolynomial, QuerySetError as QSError, EquationError as EqError};
 
 /// Error type for `MultiPCFromSinglePC`.
 #[derive(Debug)]
@@ -32,6 +32,9 @@ pub enum Error {
     /// An error related to the `QuerySet`.
     QuerySetError(QSError),
 
+    /// An error related to the `QuerySet`.
+    EquationError(EqError),
+
     /// An error from the underlying `KZG10`.
     KZG10Error(kzg10::Error),
 }
@@ -45,6 +48,12 @@ impl From<kzg10::Error> for Error {
 impl From<QSError> for Error {
     fn from(other: QSError) -> Self {
         Error::QuerySetError(other)
+    }
+}
+
+impl From<EqError> for Error {
+    fn from(other: EqError) -> Self {
+        Error::EquationError(other)
     }
 }
 
@@ -102,6 +111,7 @@ impl std::fmt::Display for Error {
             ),
             Error::IncorrectInputLength(err) => write!(f, "{}", err),
             Error::QuerySetError(err) => write!(f, "{}", err),
+            Error::EquationError(err) => write!(f, "{}", err),
             Error::KZG10Error(err) => write!(f, "KZG10 error: {}", err),
         }
     }


### PR DESCRIPTION
Adds two new methods to `PolynomialCommitment`:
* `open_equations`, which enables producing proofs for a list of `Equation`s.
* `check_equations`, which enables checking proofs for a list of `Equations`s with respect to a list of `LabeledCommitments`.

Adds a new `Equation` struct consisting of
* a label,
* an evaluation point,
* an LHS consisting of `(F, PolynomialLabel)` pairs, and
* an RHS consisting of the claimed evaluation LHS at the evaluation point.