### PR TITLE
Expose MarlinKZG10 commitment members

### DIFF
--- a/src/marlin_pc/data_structures.rs
+++ b/src/marlin_pc/data_structures.rs
@@ -138,8 +138,13 @@ impl<E: PairingEngine> PCVerifierKey for VerifierKey<E> {
     Eq(bound = "")
 )]
 pub struct Commitment<E: PairingEngine> {
-    pub(crate) comm: kzg10::Commitment<E>,
-    pub(crate) shifted_comm: Option<kzg10::Commitment<E>>,
+    /// A KZG10 commitment to the polynomial.
+    pub comm: kzg10::Commitment<E>,
+
+    /// A KZG10 commitment to the shifted polynomial.
+    /// This is `none` if the committed polynomial does not
+    /// enforce a strict degree bound.
+    pub shifted_comm: Option<kzg10::Commitment<E>>,
 }
 
 impl<E: PairingEngine> ToBytes for Commitment<E> {


### PR DESCRIPTION
Exposing the members of the MarlinKZG10 PC commitment will be useful when reusing the commitments in external libraries. This PR changes the scopes of the members to be public.