### PR TITLE
Add `ToBytes` implementation for Marlin VK

### DIFF
--- a/src/kzg10/data_structures.rs
+++ b/src/kzg10/data_structures.rs
@@ -73,6 +73,18 @@ pub struct VerifierKey<E: PairingEngine> {
     pub prepared_beta_h: E::G2Prepared,
 }
 
+impl<E: PairingEngine> ToBytes for VerifierKey<E> {
+    #[inline]
+    fn write<W: algebra_core::io::Write>(&self, mut writer: W) -> algebra_core::io::Result<()> {
+        self.g.write(&mut writer)?;
+        self.gamma_g.write(&mut writer)?;
+        self.h.write(&mut writer)?;
+        self.beta_h.write(&mut writer)?;
+        self.prepared_h.write(&mut writer)?;
+        self.prepared_beta_h.write(&mut writer)
+    }
+}
+
 /// `Commitment` commits to a polynomial. It is output by `KZG10::commit`.
 #[derive(Derivative)]
 #[derivative(

--- a/src/marlin_pc/data_structures.rs
+++ b/src/marlin_pc/data_structures.rs
@@ -126,6 +126,20 @@ impl<E: PairingEngine> PCVerifierKey for VerifierKey<E> {
     }
 }
 
+impl<E: PairingEngine> ToBytes for VerifierKey<E> {
+    fn write<W: algebra_core::io::Write>(&self, mut writer: W) -> algebra_core::io::Result<()> {
+        self.vk.write(&mut writer)?;
+        if let Some(degree_bounds_and_shift_powers) = &self.degree_bounds_and_shift_powers {
+            for (degree_bound, shift_power) in degree_bounds_and_shift_powers {
+                writer.write_all(&degree_bound.to_le_bytes())?;
+                shift_power.write(&mut writer)?;
+            }
+        }
+        writer.write_all(&self.supported_degree.to_le_bytes())?;
+        writer.write_all(&self.max_degree.to_le_bytes())
+    }
+}
+
 /// Commitment to a polynomial that optionally enforces a degree bound.
 #[derive(Derivative)]
 #[derivative(

--- a/src/marlin_pc/data_structures.rs
+++ b/src/marlin_pc/data_structures.rs
@@ -127,9 +127,11 @@ impl<E: PairingEngine> PCVerifierKey for VerifierKey<E> {
 }
 
 impl<E: PairingEngine> ToBytes for VerifierKey<E> {
+    #[inline]
     fn write<W: algebra_core::io::Write>(&self, mut writer: W) -> algebra_core::io::Result<()> {
         self.vk.write(&mut writer)?;
         if let Some(degree_bounds_and_shift_powers) = &self.degree_bounds_and_shift_powers {
+            writer.write_all(&degree_bounds_and_shift_powers.len().to_le_bytes())?;
             for (degree_bound, shift_power) in degree_bounds_and_shift_powers {
                 writer.write_all(&degree_bound.to_le_bytes())?;
                 shift_power.write(&mut writer)?;


### PR DESCRIPTION
Having a ToBytes implementation for Marlin's VerifierKey will allow it to be easily converted to bytes in external use cases. If a ToBytes macro becomes available, these changes can be reverted.